### PR TITLE
Feature WP Steer to Zero Mod

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ This fork is only for Chrysler/Jeep vehicles!
   * [Reverse ACC +/- Speeds](#reverse-acc-----speeds)
   * [Auto Resume](#auto-resume-1)
     + [Disable on Gas](#disable-on-gas)
-  * [Steer at Zero](#zero-steer-1)
+  * [Enable White Panda Steering Intercept](#wp-steering-intercept)
+  * [Minimum Steer Speed](#minimum-steer-speed)
   * [Auto Follow](#auto-follow-1)
     + [1-2 Bar Change Over](#1-2-bar-change-over)
     + [2-3 Bar Change Over](#2-3-bar-change-over)
@@ -174,10 +175,19 @@ When enabled, jvePilot will disengage when you press the gas
 * Default: Off
 * Vehicle Restart Required: Yes
 
-## Steer at Zero
-When enabled, jvePilot will attempt to steer all the way to 0mph.  If a [hardware interceptor](https://github.com/xps-genesis/panda/tree/xps_wp_chrysler_basic) is not inplace this will cause LKAS errors.
-* Default: Off
+## Enable White Panda Steering Intercept
+When enabled, jvePilot will allow you steer all the way to 0mph.  If a [hardware interceptor](https://github.com/xps-genesis/panda/tree/xps_wp_chrysler_basic).
+* Default: 0
 * Vehicle Restart Required: Yes
+* Min/Max values (0, 1)
+
+## Minimum Steer Speed
+Adjust minimum speed Openpilot will attempt to steer the vehicle. Changing this below your car's threshold will likely cause an lkas fault.
+For 2018 and younger cars limit was 3.8, newer cars 17.5 seems to be the limit.
+* Default: 17.5
+* Units: Meters per Second
+* Vehicle Restart Required: Yes
+* Min/Max values (0, 28)
 
 ## Auto Follow
 If you don't want auto follow enabled on every start, turn this off.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This fork is only for Chrysler/Jeep vehicles!
   * [Reverse ACC +/- Speeds](#reverse-acc-----speeds)
   * [Auto Resume](#auto-resume-1)
     + [Disable on Gas](#disable-on-gas)
+  * [Steer at Zero](#zero-steer-1)
   * [Auto Follow](#auto-follow-1)
     + [1-2 Bar Change Over](#1-2-bar-change-over)
     + [2-3 Bar Change Over](#2-3-bar-change-over)
@@ -170,6 +171,11 @@ This feature allows jvePilot to auto resume from an ACC stop.
 
 ## Disable on Gas
 When enabled, jvePilot will disengage when you press the gas
+* Default: Off
+* Vehicle Restart Required: Yes
+
+## Steer at Zero
+When enabled, jvePilot will attempt to steer all the way to 0mph.  If a [hardware interceptor](https://github.com/xps-genesis/panda/tree/xps_wp_chrysler_basic) is not inplace this will cause LKAS errors.
 * Default: Off
 * Vehicle Restart Required: Yes
 

--- a/selfdrive/car/chrysler/carstate.py
+++ b/selfdrive/car/chrysler/carstate.py
@@ -28,7 +28,7 @@ class CarState(CarStateBase):
 
   def update(self, cp, cp_cam):
     speed_adjust_ratio = self.cachedParams.get_float('jvePilot.settings.speedAdjustRatio', 5000)
-    steer_zero_disabled = (self.cachedParams.get('jvePilot.settings.enableSteerToZero', 5000) != "1")
+    enable_white_panda_steer = (self.cachedParams.get('jvePilot.settings.enableWhitePandaSteer', 5000) == "1")
     inverse_speed_adjust_ratio = 2 - speed_adjust_ratio
 
     ret = car.CarState.new_message()
@@ -75,7 +75,13 @@ class CarState(CarStateBase):
     ret.steeringTorqueEps = cp.vl["EPS_STATUS"]["TORQUE_MOTOR"]
     ret.steeringPressed = abs(ret.steeringTorque) > STEER_THRESHOLD
     steer_state = cp.vl["EPS_STATUS"]["LKAS_STATE"]
-    ret.steerError = steer_state == 4 or (steer_state == 0 and (ret.vEgo > self.CP.minSteerSpeed and steer_zero_disabled))
+
+    if steer_state == 4:
+      ret.steerError = true
+    elif steer_state == 0 and not enable_white_panda_steer:
+      ret.steerError = (ret.vEgo > self.CP.minSteerSpeed)
+    else:
+      ret.steerError = false
 
     ret.genericToggle = bool(cp.vl["STEERING_LEVERS"]['HIGH_BEAM_FLASH'])
     

--- a/selfdrive/car/chrysler/carstate.py
+++ b/selfdrive/car/chrysler/carstate.py
@@ -28,6 +28,7 @@ class CarState(CarStateBase):
 
   def update(self, cp, cp_cam):
     speed_adjust_ratio = self.cachedParams.get_float('jvePilot.settings.speedAdjustRatio', 5000)
+    steer_zero_disabled = (self.cachedParams.get('jvePilot.settings.enableSteerToZero', 5000) != "1")
     inverse_speed_adjust_ratio = 2 - speed_adjust_ratio
 
     ret = car.CarState.new_message()
@@ -74,7 +75,7 @@ class CarState(CarStateBase):
     ret.steeringTorqueEps = cp.vl["EPS_STATUS"]["TORQUE_MOTOR"]
     ret.steeringPressed = abs(ret.steeringTorque) > STEER_THRESHOLD
     steer_state = cp.vl["EPS_STATUS"]["LKAS_STATE"]
-    ret.steerError = steer_state == 4 or (steer_state == 0 and ret.vEgo > self.CP.minSteerSpeed)
+    ret.steerError = steer_state == 4 or (steer_state == 0 and (ret.vEgo > self.CP.minSteerSpeed and steer_zero_disabled))
 
     ret.genericToggle = bool(cp.vl["STEERING_LEVERS"]['HIGH_BEAM_FLASH'])
     

--- a/selfdrive/car/chrysler/interface.py
+++ b/selfdrive/car/chrysler/interface.py
@@ -20,7 +20,7 @@ class CarInterface(CarInterfaceBase):
   def get_params(candidate, fingerprint=gen_empty_fingerprint(), car_fw=None):
     speed_adjust_ratio = cachedParams.get_float('jvePilot.settings.speedAdjustRatio', 5000)
     inverse_speed_adjust_ratio = 2 - speed_adjust_ratio
-    steer_zero_enabled = (cachedParams.get('jvePilot.settings.enableSteerToZero', 5000) == "1")
+    min_steer_speed = cachedParams.get_float('jvePilot.settings.minSteerSpeed', 5000)
 
     ret = CarInterfaceBase.get_std_params(candidate, fingerprint)
     ret.carName = "chrysler"
@@ -48,13 +48,8 @@ class CarInterface(CarInterfaceBase):
 
     ret.centerToFront = ret.wheelbase * 0.44
 
-    ret.minSteerSpeed = 3.8 * inverse_speed_adjust_ratio  # m/s
-    if candidate in (CAR.PACIFICA_2019_HYBRID, CAR.PACIFICA_2020, CAR.JEEP_CHEROKEE_2019):
-      # TODO allow 2019 cars to steer down to 13 m/s if already engaged.
-      if steer_zero_enabled:
-        ret.minSteerSpeed = 0
-      else:
-        ret.minSteerSpeed = 17.5 * inverse_speed_adjust_ratio  # m/s 17 on the way up, 13 on the way down once engaged.
+    # TODO allow 2019 cars to steer down to 13 m/s if already engaged.
+    ret.minSteerSpeed = min_steer_speed * inverse_speed_adjust_ratio  # m/s 17 on the way up, 13 on the way down once engaged.
 
     # starting with reasonable value for civic and scaling by mass and wheelbase
     ret.rotationalInertia = scale_rot_inertia(ret.mass, ret.wheelbase)

--- a/selfdrive/car/chrysler/interface.py
+++ b/selfdrive/car/chrysler/interface.py
@@ -20,6 +20,7 @@ class CarInterface(CarInterfaceBase):
   def get_params(candidate, fingerprint=gen_empty_fingerprint(), car_fw=None):
     speed_adjust_ratio = cachedParams.get_float('jvePilot.settings.speedAdjustRatio', 5000)
     inverse_speed_adjust_ratio = 2 - speed_adjust_ratio
+    steer_zero_enabled = (cachedParams.get('jvePilot.settings.enableSteerToZero', 5000) == "1")
 
     ret = CarInterfaceBase.get_std_params(candidate, fingerprint)
     ret.carName = "chrysler"
@@ -50,7 +51,10 @@ class CarInterface(CarInterfaceBase):
     ret.minSteerSpeed = 3.8 * inverse_speed_adjust_ratio  # m/s
     if candidate in (CAR.PACIFICA_2019_HYBRID, CAR.PACIFICA_2020, CAR.JEEP_CHEROKEE_2019):
       # TODO allow 2019 cars to steer down to 13 m/s if already engaged.
-      ret.minSteerSpeed = 17.5 * inverse_speed_adjust_ratio  # m/s 17 on the way up, 13 on the way down once engaged.
+      if steer_zero_enabled:
+        ret.minSteerSpeed = 0
+      else:
+        ret.minSteerSpeed = 17.5 * inverse_speed_adjust_ratio  # m/s 17 on the way up, 13 on the way down once engaged.
 
     # starting with reasonable value for civic and scaling by mass and wheelbase
     ret.rotationalInertia = scale_rot_inertia(ret.mass, ret.wheelbase)

--- a/selfdrive/common/params.cc
+++ b/selfdrive/common/params.cc
@@ -161,6 +161,7 @@ std::unordered_map<std::string, uint32_t> keys = {
     {"jvePilot.settings.slowInCurves.speedDropOff", PERSISTENT},
     {"jvePilot.settings.slowInCurves.speedDropOffAngle", PERSISTENT},
     {"jvePilot.settings.speedAdjustRatio", PERSISTENT},
+    {"jvePilot.settings.enableSteerToZero", PERSISTENT},
 
     {"AccessToken", CLEAR_ON_MANAGER_START},
     {"ApiCache_DriveStats", PERSISTENT},

--- a/selfdrive/common/params.cc
+++ b/selfdrive/common/params.cc
@@ -161,7 +161,8 @@ std::unordered_map<std::string, uint32_t> keys = {
     {"jvePilot.settings.slowInCurves.speedDropOff", PERSISTENT},
     {"jvePilot.settings.slowInCurves.speedDropOffAngle", PERSISTENT},
     {"jvePilot.settings.speedAdjustRatio", PERSISTENT},
-    {"jvePilot.settings.enableSteerToZero", PERSISTENT},
+    {"jvePilot.settings.enableWhitePandaSteer", PERSISTENT},
+    {"jvePilot.settings.minSteerSpeed", PERSISTENT},
 
     {"AccessToken", CLEAR_ON_MANAGER_START},
     {"ApiCache_DriveStats", PERSISTENT},

--- a/selfdrive/manager/manager.py
+++ b/selfdrive/manager/manager.py
@@ -52,7 +52,8 @@ def manager_init():
     ("jvePilot.settings.slowInCurves.speedDropOff", "2.0"),
     ("jvePilot.settings.slowInCurves.speedDropOffAngle", "0.0"),
     ("jvePilot.settings.speedAdjustRatio", "1.00"),
-    ("jvePilot.settings.enableSteerToZero", "0"),
+    ("jvePilot.settings.enableWhitePandaSteer", "0"),
+    ("jvePilot.settings.minSteerSpeed", "17.5"),
 
     ("CompletedTrainingVersion", "0"),
     ("HasAcceptedTerms", "0"),

--- a/selfdrive/manager/manager.py
+++ b/selfdrive/manager/manager.py
@@ -52,6 +52,7 @@ def manager_init():
     ("jvePilot.settings.slowInCurves.speedDropOff", "2.0"),
     ("jvePilot.settings.slowInCurves.speedDropOffAngle", "0.0"),
     ("jvePilot.settings.speedAdjustRatio", "1.00"),
+    ("jvePilot.settings.enableSteerToZero", "0"),
 
     ("CompletedTrainingVersion", "0"),
     ("HasAcceptedTerms", "0"),

--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -97,6 +97,12 @@ JvePilotTogglesPanel::JvePilotTogglesPanel(QWidget *parent) : QWidget(parent) {
                                   "When enabled, jvePilot will disengage jvePilot when the gas pedal is pressed.",
                                   "../assets/jvepilot/settings/icon_gas_pedal.png",
                                   this));
+  // enableStereToZero
+  toggles.append(new ParamControl("jvePilot.settings.enableSteerToZero",
+                                  "Steer to 0 (White Panda Required)",
+                                  "When enabled, jvePilot will take advantage of eps intercept hardware and allow steering to 0mph.",
+                                  "../assets/offroad/icon_speed_limit.png",
+                                  this));
 
   // accEco
   QList<struct ConfigButton> ecoConfigs = {

--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -97,13 +97,6 @@ JvePilotTogglesPanel::JvePilotTogglesPanel(QWidget *parent) : QWidget(parent) {
                                   "When enabled, jvePilot will disengage jvePilot when the gas pedal is pressed.",
                                   "../assets/jvepilot/settings/icon_gas_pedal.png",
                                   this));
-  // enableStereToZero
-  toggles.append(new ParamControl("jvePilot.settings.enableSteerToZero",
-                                  "Steer to 0 (White Panda Required)",
-                                  "When enabled, jvePilot will take advantage of eps intercept hardware and allow steering to 0mph.",
-                                  "../assets/offroad/icon_speed_limit.png",
-                                  this));
-
   // accEco
   QList<struct ConfigButton> ecoConfigs = {
     { "jvePilot.settings.accEco.speedAheadLevel1",
@@ -168,6 +161,18 @@ JvePilotTogglesPanel::JvePilotTogglesPanel(QWidget *parent) : QWidget(parent) {
       "Ratio at Follow Level 4",
       "Default: 1.1, Min: 0.5, Max: 4.0\n"
         "At follow level 4, apply this ratio to the radar distance."
+    },
+    { "jvePilot.settings.enableWhitePandaSteer",
+      0, 1,
+      "Enable flag for WhitePanda 0 Steer Mod",
+      "Default: 0, Min: 0, Max: 1\n"
+        "Set to 1 to enable modification."
+    },
+    { "jvePilot.settings.minSteerSpeed",
+      0, 28,
+      "Speed at which OpenPilot will begin steering the car.",
+      "Default: 17.5, Min: 0, Max: 28\n"
+        "Unit of measure is in meters per second, 17.5 is 39mph, 3.8 is 9mph"
     }
   };
   toggles.append(new LabelControl("jvePilot Control Settings",


### PR DESCRIPTION
This branch adds support for taking advantage of a white panda to
intercept messages being sent. It enables the car to steer to 0mph
removing the 9mph and 39mph lockouts

cleaned up a bit from what we had discussed and added readme info.