### PR TITLE
Feature Minimum Steer Offset adjust, and enable for white panda eps interceptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ This fork is only for Chrysler/Jeep vehicles!
   * [Reverse ACC +/- Speeds](#reverse-acc-----speeds)
   * [Auto Resume](#auto-resume-1)
     + [Disable on Gas](#disable-on-gas)
+  * [Enable White Panda Steering Intercept](#wp-steering-intercept)
+  * [Minimum Steer Speed Offset](#minimum-steer-speed-offset)
   * [Auto Follow](#auto-follow-1)
     + [1-2 Bar Change Over](#1-2-bar-change-over)
     + [2-3 Bar Change Over](#2-3-bar-change-over)
@@ -172,6 +174,20 @@ This feature allows jvePilot to auto resume from an ACC stop.
 When enabled, jvePilot will disengage when you press the gas
 * Default: Off
 * Vehicle Restart Required: Yes
+
+## Enable White Panda Steering Intercept
+When enabled, jvePilot will allow you steer all the way to 0mph.  If a [hardware interceptor](https://github.com/xps-genesis/panda/tree/xps_wp_chrysler_basic).
+* Default: 0
+* Vehicle Restart Required: Yes
+* Min/Max values (0, 1)
+
+## Minimum Steer Speed Offset
+Adjust minimum speed Openpilot will attempt to steer the vehicle. Changing this below your car's threshold will likely cause an lkas fault.
+For 2018 and younger cars limit was 3.8, newer cars 17.5 seems to be the limit. If your car's limit was 17.5, and you set -1, it will try to steer to 16.5
+* Default: 0
+* Units: Meters per Second
+* Vehicle Restart Required: Yes
+* Min/Max values (-28, 28)
 
 ## Auto Follow
 If you don't want auto follow enabled on every start, turn this off.

--- a/selfdrive/car/chrysler/interface.py
+++ b/selfdrive/car/chrysler/interface.py
@@ -20,6 +20,7 @@ class CarInterface(CarInterfaceBase):
   def get_params(candidate, fingerprint=gen_empty_fingerprint(), car_fw=None):
     speed_adjust_ratio = cachedParams.get_float('jvePilot.settings.speedAdjustRatio', 5000)
     inverse_speed_adjust_ratio = 2 - speed_adjust_ratio
+    min_steer_speed_offset = cachedParams.get_float('jvePilot.settings.minSteerSpeedOffset', 5000)
 
     ret = CarInterfaceBase.get_std_params(candidate, fingerprint)
     ret.carName = "chrysler"
@@ -46,11 +47,10 @@ class CarInterface(CarInterfaceBase):
       ret.enableBsm = True
 
     ret.centerToFront = ret.wheelbase * 0.44
-
-    ret.minSteerSpeed = 3.8 * inverse_speed_adjust_ratio  # m/s
+    ret.minSteerSpeed = (3.8 + min_steer_speed_offset) * inverse_speed_adjust_ratio  # m/s
     if candidate in (CAR.PACIFICA_2019_HYBRID, CAR.PACIFICA_2020, CAR.JEEP_CHEROKEE_2019):
       # TODO allow 2019 cars to steer down to 13 m/s if already engaged.
-      ret.minSteerSpeed = 17.5 * inverse_speed_adjust_ratio  # m/s 17 on the way up, 13 on the way down once engaged.
+      ret.minSteerSpeed = (17.5 + min_steer_speed_offset) * inverse_speed_adjust_ratio  # m/s 17 on the way up, 13 on the way down once engaged.
 
     # starting with reasonable value for civic and scaling by mass and wheelbase
     ret.rotationalInertia = scale_rot_inertia(ret.mass, ret.wheelbase)

--- a/selfdrive/common/params.cc
+++ b/selfdrive/common/params.cc
@@ -161,6 +161,8 @@ std::unordered_map<std::string, uint32_t> keys = {
     {"jvePilot.settings.slowInCurves.speedDropOff", PERSISTENT},
     {"jvePilot.settings.slowInCurves.speedDropOffAngle", PERSISTENT},
     {"jvePilot.settings.speedAdjustRatio", PERSISTENT},
+    {"jvePilot.settings.enableWhitePandaSteer", PERSISTENT},
+    {"jvePilot.settings.minSteerSpeedOffset", PERSISTENT},
 
     {"AccessToken", CLEAR_ON_MANAGER_START},
     {"ApiCache_DriveStats", PERSISTENT},

--- a/selfdrive/manager/manager.py
+++ b/selfdrive/manager/manager.py
@@ -52,6 +52,8 @@ def manager_init():
     ("jvePilot.settings.slowInCurves.speedDropOff", "2.0"),
     ("jvePilot.settings.slowInCurves.speedDropOffAngle", "0.0"),
     ("jvePilot.settings.speedAdjustRatio", "1.00"),
+    ("jvePilot.settings.enableWhitePandaSteer", "0"),
+    ("jvePilot.settings.minSteerSpeedOffset", "0"),
 
     ("CompletedTrainingVersion", "0"),
     ("HasAcceptedTerms", "0"),

--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -97,7 +97,6 @@ JvePilotTogglesPanel::JvePilotTogglesPanel(QWidget *parent) : QWidget(parent) {
                                   "When enabled, jvePilot will disengage jvePilot when the gas pedal is pressed.",
                                   "../assets/jvepilot/settings/icon_gas_pedal.png",
                                   this));
-
   // accEco
   QList<struct ConfigButton> ecoConfigs = {
     { "jvePilot.settings.accEco.speedAheadLevel1",
@@ -162,6 +161,18 @@ JvePilotTogglesPanel::JvePilotTogglesPanel(QWidget *parent) : QWidget(parent) {
       "Ratio at Follow Level 4",
       "Default: 1.1, Min: 0.5, Max: 4.0\n"
         "At follow level 4, apply this ratio to the radar distance."
+    },
+    { "jvePilot.settings.minSteerSpeedOffset",
+      -28, 28,
+      "Minimum Speed Steering Offset.",
+      "Default: 0, Min: -28, Max: 28\n"
+        "Unit of measure is in meters per second, 17.5 is 39mph, 3.8 is 9mph"
+    },
+    { "jvePilot.settings.enableWhitePandaSteer",
+      0, 1,
+      "Enable flag for WhitePanda 0 Steer Mod",
+      "Default: 0, Min: 0, Max: 1\n"
+        "Set to 1 to enable modification."
     }
   };
   toggles.append(new LabelControl("jvePilot Control Settings",


### PR DESCRIPTION
This branch adds support for adjusting minimum steering by applying an offset
to the value.

This branch also adds support for taking advantage of a white panda to
intercept messages being sent. It enables the car to steer to 0mph
removing the 9mph and 39mph lockouts.